### PR TITLE
Fix for aborted requests in IE9

### DIFF
--- a/src/ajax/xdr.js
+++ b/src/ajax/xdr.js
@@ -11,7 +11,7 @@ if ( window.XDomainRequest ) {
 			return {
 				send: function( _, complete ) {
 					function callback( status, statusText, responses, responseHeaders ) {
-						xdr.onload = xdr.onerror = xdr.ontimeout = jQuery.noop;
+						xdr.onload = xdr.onerror = xdr.ontimeout = xdr.onprogress = jQuery.noop;
 						xdr = undefined;
 						complete( status, statusText, responses, responseHeaders );
 					}
@@ -23,6 +23,7 @@ if ( window.XDomainRequest ) {
 					xdr.onerror = function() {
 						callback( 404, "Not Found" );
 					};
+					xdr.onprogress = function() {};
 					if ( s.xdrTimeout ) {
 						xdr.ontimeout = function() {
 							callback( 0, "timeout" );


### PR DESCRIPTION
Hello,

I noticed your code referenced from here: http://bugs.jquery.com/ticket/8283 and when I tried it out, it worked perfectly in IE8, but not on IE9.  It looks like for IE9, you need to define the onprogress handler or requests will abort: http://social.msdn.microsoft.com/Forums/en-US/iewebdevelopment/thread/30ef3add-767c-4436-b8a9-f1ca19b4812e

From my testing, setting this handler to jQuery.noop wasn't sufficient, but the empty function is.  

Hope this helps someone!

Tom
