### PR TITLE
Only use XDomainRequest on IE version < 10

### DIFF
--- a/src/xdr.js
+++ b/src/xdr.js
@@ -1,4 +1,4 @@
-if ( window.XDomainRequest ) {
+if ( window.XDomainRequest && jQuery.browser.msie && parseInt(jQuery.browser.version.split('.')[0]) < 10) {
 	jQuery.ajaxTransport(function( s ) {
 		if ( s.crossDomain && s.async ) {
 			if ( s.timeout ) {


### PR DESCRIPTION
IE 10 features proper CORS support with XHR2, so there is no longer a reason to use the clearly inferior XDomainRequest on IE 10.
