### PR TITLE
Fix request aborting and schema-relative urls

### DIFF
--- a/src/xdr.js
+++ b/src/xdr.js
@@ -25,7 +25,7 @@ if ( window.XDomainRequest ) {
 						callback( 0, "timeout" );
 					};
 					xdr.timeout = s.xdrTimeout || Number.MAX_VALUE;
-					xdr.open( s.type, s.url );
+					xdr.open( s.type, s.url.replace(/^https?:/, '') );
 					xdr.send( ( s.hasContent && s.data ) || null );
 				},
 				abort: function() {

--- a/src/xdr.js
+++ b/src/xdr.js
@@ -20,7 +20,7 @@ if ( window.XDomainRequest ) {
 					xdr.onerror = function() {
 						callback( 404, "Not Found" );
 					};
-					xdr.onprogress = jQuery.noop;
+					xdr.onprogress = function() {};
 					xdr.ontimeout = function() {
 						callback( 0, "timeout" );
 					};


### PR DESCRIPTION
First about aborting. This is unexplainably magic. I can only suppose what IE require closure in this place. But this is fact: requests with `onprogress = $.noop` fails in many cases (long request, long response, slow connection).

Schema-relative urls required because «Requests must be targeted to the same scheme as the hosting page» is [one of XDomainRequest limitation](http://blogs.msdn.com/b/ieinternals/archive/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds.aspx). As I can see schema-relative urls works fine in this place.
